### PR TITLE
Color Fix for Polls

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -334,6 +334,16 @@ svg[fill="hsl(359, calc(var(--saturation-factor, 1) * 82.6%), 59.4%)"] {
   background-color: var(--background-secondary);
 }
 
+/* Polls */
+.pollContainer__95d4b {
+  background-color: var(--background-secondary) !important;
+}
+
+.answerInner_a3bc8e {
+  background-color: var(--background-primary) !important;
+  
+}
+
 /* ~~~~		  		Popouts							~~~~ */
 
 /* User Popouts */

--- a/src/main.css
+++ b/src/main.css
@@ -341,7 +341,6 @@ svg[fill="hsl(359, calc(var(--saturation-factor, 1) * 82.6%), 59.4%)"] {
 
 .answerInner_a3bc8e {
   background-color: var(--background-primary) !important;
-  
 }
 
 /* ~~~~		  		Popouts							~~~~ */


### PR DESCRIPTION
Discord recently [added a new feature called Polls](https://support.discord.com/hc/en-us/articles/22163184112407-Polls-FAQ), which looks a little out of place right now with the current theme
![How the poll currently looks](https://github.com/Dyzean/Tokyo-Night/assets/44043775/2f40cc95-4c1e-46d8-98d2-a472c71b3d50)
This should add the default colors that fit more with the theme
![My version](https://github.com/Dyzean/Tokyo-Night/assets/44043775/d75b7c22-525f-4768-8385-7bc5d2c8c7ef)

